### PR TITLE
Add left padding to title

### DIFF
--- a/packages/core/template/default/stylesheets/main.css
+++ b/packages/core/template/default/stylesheets/main.css
@@ -105,6 +105,10 @@ mark {
     }
 }
 
+#page-nav .nav-component .navbar-brand.page-nav-title {
+    padding-left: 0.3125rem;
+}
+ 
 /* Bootstrap medium(md) responsive breakpoint */
 @media screen and (max-width: 991.98px) {
     #site-nav {


### PR DESCRIPTION
**What is the purpose of this pull request?**

- [ ] Documentation update
- [x] Bug fix
- [ ] Feature addition or enhancement
- [ ] Code maintenance
- [ ] Others, please explain:

Fixes #1614

**Overview of changes:**
Added a padding-left of 0.3125 rem which is the same as the element's padding-top and padding-bottom.
![image](https://user-images.githubusercontent.com/57279935/124082781-b0fcee80-da7f-11eb-9c67-c5fcbf5b8fc7.png)


**Anything you'd like to highlight / discuss:**


**Testing instructions:**


**Proposed commit message: (wrap lines at 72 characters)**
Add left padding to title

---

**Checklist:** :ballot_box_with_check:


- [ ] Updated the documentation for feature additions and enhancements
- [ ] Added tests for bug fixes or features
- [x] Linked all related issues
- [x] No blatantly unrelated changes
- [ ] Pinged someone for a review!
